### PR TITLE
feat : 유저상세페이지 수정, 등록시 분기별 API 연결완료

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="src/assets/image/icons/logo.svg"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=8aec9c86848f0830eadf549969efde23&libraries=services,clusterer"></script>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=8aec9c86848f0830eadf549969efde23&libraries=services,clusterer"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/common/header/MainHeader.tsx
+++ b/src/components/common/header/MainHeader.tsx
@@ -39,7 +39,7 @@ export default function MainHeader() {
           />
           <Avatar
             onClick={handleClickToMy}
-            className="mr-3 cursor-pointer "
+            className="mr-3 cursor-pointer"
             alt="User settings"
             img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
             rounded

--- a/src/lib/apis/user.tsx
+++ b/src/lib/apis/user.tsx
@@ -69,7 +69,7 @@ export async function getUserInfo() {
 }
 
 //회원정보 수정(PUT)
-export async function updateUserInfo(data: User) {
+export async function updateUserInfo(data: UserInfo) {
   return await userInstance.put('/user-info', data);
 }
 

--- a/src/routes/map/MapSearch.tsx
+++ b/src/routes/map/MapSearch.tsx
@@ -18,7 +18,7 @@ export default function MapSearch({}: Props) {
 
   return (
     <div>
-      <Navbar className="flex h-16">
+      <div className="flex h-16">
         <div className="flex w-full">
           <input
             className="flex-grow ml-2 text-[1.2rem] px-2 py-1"
@@ -27,11 +27,15 @@ export default function MapSearch({}: Props) {
             required
             style={{ minWidth: '200px' }}
           />
-          <div className="flex items-center px-2">
-            <img className="h-6" src={search} alt="Search Icon" />
+          <div className="flex md:order-2 items-center px-2">
+            <img
+              className="flex h-[2rem] cursor-pointer"
+              src={search}
+              alt="Search Icon"
+            />
           </div>
         </div>
-      </Navbar>
+      </div>
       <div>
         <ul>
           {array.map((element, index) => (

--- a/src/routes/mypage/Mypage.tsx
+++ b/src/routes/mypage/Mypage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import profileTest from '../../assets/image/test/profile-test.svg';
 import FavoriteRooms from '../../components/mypage/FavoriteRooms';
 import PlusButton from '../../components/common/button/PlusButton';
@@ -6,9 +6,22 @@ import FavoriteLoans from '../../components/mypage/FavoriteLoans';
 import home from '../../assets/image/icons/home.svg';
 import loan from '../../assets/image/icons/loan.svg';
 import { useNavigate } from 'react-router-dom';
+import { getUserInfo, isvalidateToken } from '@/lib/apis/user';
+import { AxiosError } from 'axios';
+import { ErrorResponseI } from '@/utils/errorTypes';
 // import { test } from '@/lib/apis/my';
 
+interface UserInfo {
+  birthDate: string;
+  email: string;
+  nickname: string;
+  userId: number;
+  userInfo: any; // Modify this type based on the actual structure
+}
+
 export default function Mypage() {
+  const [user, setUser] = useState<UserInfo | null>(null);
+
   const navigate = useNavigate();
   const handleToMyLoan = () => navigate('/my/loan');
   const handleToMyProperties = () => navigate('/my/properties');
@@ -20,9 +33,29 @@ export default function Mypage() {
       console.error('회원가입 실패:', error);
     }
   };
+
   useEffect(() => {
     // handleSignUp();
   }, []);
+
+  useEffect(() => {
+    const validateAndFetchUserInfo = async () => {
+      try {
+        await isvalidateToken();
+        const userInfo = await getUserInfo();
+        setUser(userInfo.data.response);
+      } catch (error: unknown) {
+        const errorResponse = error as AxiosError<ErrorResponseI>;
+        if (errorResponse.response) {
+          console.log(errorResponse.response.data.response);
+        }
+        navigate('/user/login');
+      }
+    };
+
+    validateAndFetchUserInfo();
+  }, [navigate]);
+
   return (
     <div className="w-customWidthPercent">
       <div className="flex flex-row items-center">
@@ -34,10 +67,8 @@ export default function Mypage() {
           />
         </div>
         <div className="flex flex-col w-[80%]">
-          <div className="font-bold text-[1.2rem]">김영석</div>
-          <div className="text-[1rem] text-grey-1">
-            kimyoungseok15@gmail.com
-          </div>
+          <div className="font-bold text-[1.2rem]">{user?.nickname}</div>
+          <div className="text-[1rem] text-grey-1">{user?.email}</div>
         </div>
       </div>
       <div className="py-[1rem] " />

--- a/src/routes/mypage/MypageEdit.tsx
+++ b/src/routes/mypage/MypageEdit.tsx
@@ -30,7 +30,6 @@ export default function MypageEdit() {
       try {
         await isvalidateToken();
         const userInfo = await getUserInfo();
-        console.log(userInfo);
         setUser(userInfo.data.response);
       } catch (error: unknown) {
         const errorResponse = error as AxiosError<ErrorResponseI>;
@@ -50,6 +49,7 @@ export default function MypageEdit() {
 
   const handleClickedUserInfoButton = async () => {
     const resp = await getUserInfo();
+    console.log(resp);
     if (resp.data.response.userInfo) navigate('/user/info/1');
     else navigate('/user/info/2');
   };

--- a/src/routes/user/LoginMain.tsx
+++ b/src/routes/user/LoginMain.tsx
@@ -15,13 +15,15 @@ export default function Login() {
   const handleKakaoLogin = async () => {
     try {
       await kakaoLogin();
-      navigate('/');
+      // navigate('/');
     } catch (error: unknown) {
       const errorResponse = error as AxiosError<ErrorResponseI>;
       if (errorResponse.response) {
         console.error(errorResponse.response.data.response);
       }
       navigate('/user/login');
+    } finally {
+      navigate('/');
     }
   };
 
@@ -94,15 +96,15 @@ export default function Login() {
         </div>
 
         <div className="flex flex-col mb-4 w-customWidthPercent">
-          <a href="http://3.39.52.110:3000/api/oauth2/authorization/kakao">
-            <button
-              className=" w-full flex items-center justify-between h-[57px] bg-[#FEE500] border-none rounded-[5px] px-4"
-              // onClick={handleKakaoLogin}
-            >
-              <img src={KaKaoBtn} alt="kakao" className="h-6" />
-              <div className="w-full text-center">카카오로 시작하기</div>
-            </button>
-          </a>
+          {/* <a href="http://3.39.52.110:3000/api/oauth2/authorization/kakao"> */}
+          <button
+            className=" w-full flex items-center justify-between h-[57px] bg-[#FEE500] border-none rounded-[5px] px-4"
+            onClick={handleKakaoLogin}
+          >
+            <img src={KaKaoBtn} alt="kakao" className="h-6" />
+            <div className="w-full text-center">카카오로 시작하기</div>
+          </button>
+          {/* </a> */}
         </div>
       </div>
     </div>

--- a/src/routes/user/UserInfoInput.tsx
+++ b/src/routes/user/UserInfoInput.tsx
@@ -1,15 +1,22 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import UserInfoInputFirst from './UserInfoInputFirst';
 import UserInfoInputSecond from './UserInfoInputSecond';
 import UserInfoInputThird from './UserInfoInputThird';
 import UserInfoInputDone from './UserInfoInputDone';
-import { registerAdditionalUserInfo } from '@/lib/apis/user';
-import { useNavigate } from 'react-router-dom';
+import {
+  getUserInfo,
+  registerAdditionalUserInfo,
+  updateUserInfo,
+} from '@/lib/apis/user';
+import { Params, useNavigate, useParams } from 'react-router-dom';
 import { ErrorResponseI } from '@/utils/errorTypes';
 import { AxiosError } from 'axios';
 
 export default function UserInfoInput() {
   const navigate = useNavigate();
+  const { option } = useParams<Params>();
+
+  useEffect(() => {}, [option]);
 
   //1페이지에 필요한 state
   const [pageNum, setPageNum] = useState<number>(1);
@@ -31,9 +38,40 @@ export default function UserInfoInput() {
   const [totalMarriedIncome, setTotalMarriedIncome] = useState<number>();
   const [totalMarriedAssets, setTotalMarriedAssets] = useState<number>();
 
-  const AddUserInfo = async () => {
+  useEffect(() => {
+    if (option === '1') {
+      const fetchUserInfo = async () => {
+        try {
+          const response = await getUserInfo();
+          const userInfo = response.data.response.userInfo;
+          console.log(userInfo);
+          setIndividualAssets(userInfo.individualAssets);
+          setIndividualIncome(userInfo.individualIncome);
+          setIsFirstHouseBuyer(userInfo.isFirstHouseBuyer);
+          setHasOtherLoans(userInfo.hasOtherLoans);
+
+          setIsForeign(userInfo.isForeign);
+          setOccupation(userInfo.occupation);
+          setEmploymentDuration(userInfo.employmentDuration);
+          setCompanySize(userInfo.companySize);
+
+          setIsMarried(userInfo.isMarried);
+          setYearsOfMarriage(userInfo.yearsOfMarriage);
+          setChildrenCount(userInfo.childrenCount);
+          setTotalMarriedAssets(userInfo.totalMarriedAssets);
+          setTotalMarriedIncome(userInfo.totalMarriedIncome);
+        } catch (error) {
+          console.error('Failed to fetch user info:', error);
+        }
+      };
+
+      fetchUserInfo();
+    }
+  }, []);
+
+  const AddOrUpdateUserInfo = async () => {
     try {
-      await registerAdditionalUserInfo({
+      const data = {
         occupation,
         companySize,
         employmentDuration,
@@ -47,7 +85,12 @@ export default function UserInfoInput() {
         isMarried,
         yearsOfMarriage,
         hasOtherLoans,
-      });
+      };
+      if (option === '2') {
+        await registerAdditionalUserInfo(data);
+      } else if (option === '1') {
+        await updateUserInfo(data);
+      }
 
       navigate('/'); // 로그인 성공 후 이동할 경로
     } catch (error: unknown) {
@@ -56,7 +99,7 @@ export default function UserInfoInput() {
       if (errorResponse.response && errorResponse.response.status === 500) {
         console.log(errorResponse.response.data.response.message);
       } else {
-        console.error('로그인 에러:', error);
+        console.error('정보 입력 실패:', error);
       }
     }
   };
@@ -108,7 +151,7 @@ export default function UserInfoInput() {
             setTotalMarriedAssets={setTotalMarriedAssets}
             pageNum={pageNum}
             setPageNum={setPageNum}
-            AddUserInfo={AddUserInfo}
+            AddUserInfo={AddOrUpdateUserInfo}
           />
         );
       case 4:

--- a/src/routes/user/UserInfoInputThird.tsx
+++ b/src/routes/user/UserInfoInputThird.tsx
@@ -1,8 +1,9 @@
+import { getUserInfo } from '@/lib/apis/user';
 import LargeButton from '@components/common/button/LargeButton';
 import FloatingInputForm1 from '@components/common/form/FloatingInputForm1';
 import ProgressBar from '@components/common/progressbar/ProgressBar';
 import { useEffect, useState } from 'react';
-import { useOutletContext } from 'react-router-dom';
+import { Params, useOutletContext, useParams } from 'react-router-dom';
 
 interface Props {
   isMarried: boolean;
@@ -36,6 +37,28 @@ export default function UserInfoInputThird({
   AddUserInfo,
 }: Props) {
   const [isActive, setIsActive] = useState<number>(3);
+  const { option } = useParams<Params>();
+
+  useEffect(() => {
+    if (option === '1') {
+      const fetchUserInfo = async () => {
+        try {
+          const response = await getUserInfo();
+          const userInfo = response.data.response.userInfo;
+          console.log(userInfo);
+          setIsMarried(userInfo.isMarried);
+          setYearsOfMarriage(userInfo.yearsOfMarriage);
+          setChildrenCount(userInfo.childrenCount);
+          setTotalMarriedAssets(userInfo.totalMarriedAssets);
+          setTotalMarriedIncome(userInfo.totalMarriedIncome);
+        } catch (error) {
+          console.error('Failed to fetch user info:', error);
+        }
+      };
+
+      fetchUserInfo();
+    }
+  }, [option]);
 
   const handleMarriageStatusChange = (value: string): void => {
     if (value === 'marriage') {


### PR DESCRIPTION
## 작업 내용

- 개인정보 수정 페이지 컴포넌트를 수정시, 처음 등록할 시 모두 공유하기 때문에 버튼을 눌렀을때 분기처리가 필요
-> 기존의 /user/info url을 /user/info/:option로 변경해서 option이 수정시에는 1, 처음 입력시에는 2로 들어와서 분기별로 각 요청을 처리

<br/>
  
## 확인 사항 (option)

- 리뷰어에게

<br/>
